### PR TITLE
Add ability to send data between transitions

### DIFF
--- a/lib/stateMachine.ml
+++ b/lib/stateMachine.ml
@@ -12,8 +12,10 @@ let raise_invalid_state state states =
   raise (Invalid_transition exn)
 
 module type State = sig
+  type t
   val name : string
   val set_default : bool
+  val set_buffer : t -> unit
   val init : unit -> unit
   val update : unit -> string option
   val render : unit -> unit

--- a/lib/stateMachine.mli
+++ b/lib/stateMachine.mli
@@ -9,6 +9,9 @@ exception Empty_state_machine
 (** [State] is a state in a state machine. It is one of the input signatures for
     the functor [AddState]. *)
 module type State = sig
+  type t
+  (** [t] is the type of data that the State receives from other states. *)
+
   val name : string
   (** [name] is the name of the state. *)
 
@@ -16,6 +19,10 @@ module type State = sig
   (** [set_default] determines whether the state will override a StateMachine's
       current state when added to one. It will always be overrided if a
       StateMachine's [current_state] is [None]. *)
+
+  val set_buffer : t -> unit
+  (** [set_buffer data] sets the buffer to some data value. This buffer is used
+      to send data between states. *)
 
   val init : unit -> unit
   (** [init ()] initializes the proper graphics, textures, etc. necessary for

--- a/states/pauseState.ml
+++ b/states/pauseState.ml
@@ -1,8 +1,13 @@
 open Finalproject
 
+type t = int
+
 let name = "pause"
 let set_default = false
 let init () = ()
+
+let buffer = ref None 
+let set_buffer (t : t) = buffer := Some t
 
 let update () =
   let open Raylib in

--- a/states/pauseState.mli
+++ b/states/pauseState.mli
@@ -1,0 +1,21 @@
+type t = int
+(** [t] is the type of data another state can send to the pause state. *)
+
+val name : string
+(** [name] is ["pause"]. *)
+
+val set_default : bool
+(** [set_default] is [false] because it is not the state the game starts. *)
+
+val set_buffer : t -> unit
+(** [set_buffer data] sets the buffer of pause state. *)
+
+val init : unit -> unit
+(** [init ()] initializes the pause state. *)
+
+val update : unit -> string option
+(** [update ()] checks for keyboard input. This state can transition into the
+    play state. *)
+
+val render : unit -> unit
+(** [render ()] draws a paused sign in the middle of the screen. *)

--- a/states/playState.ml
+++ b/states/playState.ml
@@ -135,4 +135,10 @@ let render () =
        (fun note ->
          draw_rectangle_rec (Note.get_sprite note) Constants.note_color)
        notes);
-  ignore (Utils.map3 handle_key_press notes buttons Constants.bindings)
+  ignore (Utils.map3 handle_key_press notes buttons Constants.bindings);
+  draw_text
+    ("Score: " ^ string_of_int !score)
+    ((get_screen_width () * 17 / 20)
+    - (String.length (string_of_int !score) * (get_screen_width () / 200)))
+    20 30 Color.lightgray;
+  draw_fps 5 5

--- a/states/playState.ml
+++ b/states/playState.ml
@@ -1,5 +1,9 @@
 open Finalproject
 
+type t = int
+
+let buffer = ref None
+let set_buffer (t : t) = buffer := Some t
 let name = "play"
 let set_default = true
 let score = ref 0

--- a/states/playState.mli
+++ b/states/playState.mli
@@ -1,0 +1,22 @@
+type t = int
+(** [t] is the type of data another state can send to the play state. *)
+
+val name : string
+(** [name] is ["play"]. *)
+
+val set_default : bool
+(** [set_default] is [false] because it is not the state the game starts. *)
+
+val set_buffer : t -> unit
+(** [set_buffer data] sets the buffer of play state. *)
+
+val init : unit -> unit
+(** [init ()] initializes the play state. *)
+
+val update : unit -> string option
+(** [update ()] updates the position of the notes in each column. It checks for
+    keyboard input to detect timing and updates the score correspondingly. This
+    state can transition to the pause state. *)
+
+val render : unit -> unit
+(** [render ()] draws a paused sign in the middle of the screen. *)

--- a/states/titleState.ml
+++ b/states/titleState.ml
@@ -1,3 +1,5 @@
+type t = int
+
 let name = "title"
 let set_default = true
 
@@ -5,6 +7,8 @@ let texture =
   "/data/ICU.gif" |> Raylib.load_image |> Raylib.load_texture_from_image
 
 let init () = ()
+let buffer = ref None
+let set_buffer (t : t) = buffer := Some t
 
 let update () =
   let open Raylib in

--- a/states/titleState.mli
+++ b/states/titleState.mli
@@ -1,0 +1,21 @@
+type t = int
+(** [t] is the type of data another state can send to the title state. *)
+
+val name : string
+(** [name] is ["title"]. *)
+
+val set_default : bool
+(** [set_default] is [true] because it is the state the game starts. *)
+
+val set_buffer : t -> unit
+(** [set_buffer data] sets the buffer of title state. *)
+
+val init : unit -> unit
+(** [init ()] initializes the title state. *)
+
+val update : unit -> string option
+(** [update ()] checks for keyboard input. This state can transition into the
+    play state. *)
+
+val render : unit -> unit
+(** [render ()] draws the title screen *)


### PR DESCRIPTION
**Note:** Currently all `[state].ml/i` have placeholder type `t`. If you need to switch this you need to change it in both `[state].ml` and `[state].mli`.

What I opted to do is add an abstract type t in each state with a set_buffer : t -> unit function, which would be called (ideally) right before any return of a transition in update. This implies that in every state there is a buffer: t option ref  that holds the latest data of whatever state sent over data. This can then be directly referenced in each state's update method, with None representing no important data being sent.

Now the problem that arises is that the other modules do not know the abstract type t for each state. We expose this by writing whatever the type is in a corresponding .mli file (which isn't good because it duplicates code, but it works).
As an example, imagine we have two states pause and title . This is some code for title, in which every time it transitions to pause, it sets the buffer in pause.
```
(* titleState.ml *)
type t = int
let buffer = ref None
let set_buffer (t : t) = buffer := Some t
let counter = ref 0

let update () =
  let open Raylib in
  if is_key_pressed Key.Enter then (
    incr counter;
    PauseState.set_buffer !counter;
    Some "pause")
  else None
```
Inside the pause state compilation unit,
```
(* pauseState.ml *)
type t = int
let buffer = ref None
let set_buffer (t : t) = buffer := Some t
let render () =
  let open Raylib in
  draw_text
    ("Paused"
    ^
    match !buffer with
    | None -> ""
    | Some s -> " " ^ string_of_int s)
    (Constants.width / 2) (Constants.height / 2) 40 Color.red
...
(* pauseState.mli *)
type t = int
```