### PR TITLE
Used include to avoid repetition

### DIFF
--- a/states/pauseState.ml
+++ b/states/pauseState.ml
@@ -5,8 +5,7 @@ type t = int
 let name = "pause"
 let set_default = false
 let init () = ()
-
-let buffer = ref None 
+let buffer = ref None
 let set_buffer (t : t) = buffer := Some t
 
 let update () =

--- a/states/pauseState.mli
+++ b/states/pauseState.mli
@@ -1,21 +1,2 @@
-type t = int
-(** [t] is the type of data another state can send to the pause state. *)
-
-val name : string
-(** [name] is ["pause"]. *)
-
-val set_default : bool
-(** [set_default] is [false] because it is not the state the game starts. *)
-
-val set_buffer : t -> unit
-(** [set_buffer data] sets the buffer of pause state. *)
-
-val init : unit -> unit
-(** [init ()] initializes the pause state. *)
-
-val update : unit -> string option
-(** [update ()] checks for keyboard input. This state can transition into the
-    play state. *)
-
-val render : unit -> unit
-(** [render ()] draws a paused sign in the middle of the screen. *)
+open Finalproject
+include StateMachine.State with type t = int

--- a/states/playState.mli
+++ b/states/playState.mli
@@ -1,22 +1,2 @@
-type t = int
-(** [t] is the type of data another state can send to the play state. *)
-
-val name : string
-(** [name] is ["play"]. *)
-
-val set_default : bool
-(** [set_default] is [false] because it is not the state the game starts. *)
-
-val set_buffer : t -> unit
-(** [set_buffer data] sets the buffer of play state. *)
-
-val init : unit -> unit
-(** [init ()] initializes the play state. *)
-
-val update : unit -> string option
-(** [update ()] updates the position of the notes in each column. It checks for
-    keyboard input to detect timing and updates the score correspondingly. This
-    state can transition to the pause state. *)
-
-val render : unit -> unit
-(** [render ()] draws a paused sign in the middle of the screen. *)
+open Finalproject
+include StateMachine.State with type t = int

--- a/states/titleState.mli
+++ b/states/titleState.mli
@@ -1,21 +1,2 @@
-type t = int
-(** [t] is the type of data another state can send to the title state. *)
-
-val name : string
-(** [name] is ["title"]. *)
-
-val set_default : bool
-(** [set_default] is [true] because it is the state the game starts. *)
-
-val set_buffer : t -> unit
-(** [set_buffer data] sets the buffer of title state. *)
-
-val init : unit -> unit
-(** [init ()] initializes the title state. *)
-
-val update : unit -> string option
-(** [update ()] checks for keyboard input. This state can transition into the
-    play state. *)
-
-val render : unit -> unit
-(** [render ()] draws the title screen *)
+open Finalproject
+include StateMachine.State with type t = int


### PR DESCRIPTION
I used include to shorten the code in the mli files of the states. Follow this pattern if you want to add new states.